### PR TITLE
Return value must be an instance of Client, boolean returned

### DIFF
--- a/src/HemiFrame/Lib/WebSocket/WebSocket.php
+++ b/src/HemiFrame/Lib/WebSocket/WebSocket.php
@@ -328,7 +328,7 @@ class WebSocket {
         $result = @socket_connect($this->socket, $this->address, $this->port);
         if ($result === false) {
             $this->onError($this->socket);
-            return FALSE;
+            throw new \RuntimeException("Can't connect to " . $this->address . ":" . $this->port);
         }
 
         $client = $this->createClient($this->getSocket());
@@ -350,7 +350,7 @@ class WebSocket {
 
         if ($buf === false) {
             $this->disconnectClient($client, self::STATUS_CLOSE_PROTOCOL_ERROR);
-            return FALSE;
+            throw new \RuntimeException("Can't read socket");
         }
 
         $client->setHeaders($this->parseHeaders($buf));


### PR DESCRIPTION
PHP Fatal error:  Uncaught TypeError: Return value of HemiFrame\Lib\WebSocket\WebSocket::connect() must be an instance of HemiFrame\Lib\WebSocket\Client, boolean returned in vendor/hemiframe/php-websocket/src/HemiFrame/Lib/WebSocket/WebSocket.php:331