### PR TITLE
Fixed overwrite issue when passing headers

### DIFF
--- a/src/HemiFrame/Lib/WebSocket/WebSocket.php
+++ b/src/HemiFrame/Lib/WebSocket/WebSocket.php
@@ -369,8 +369,8 @@ class WebSocket
             $header .= "Origin: " . $origin . "\r\n";
         }
         if (!empty($headers)) {
-            foreach ($headers as $key => $value) {
-                $header .= "$key: " . $value . "\r\n";
+            foreach ($headers as $headerKey => $value) {
+                $header .= "$headerKey: " . $value . "\r\n";
             }
         }
         $header .= "Sec-WebSocket-Key: " . $key . "\r\n";


### PR DESCRIPTION
Hey, I found a issue when passing $headers in the connect() method - internally the variable $key gets overwritten which passes a wrong handshake key as header.

```
        $this->client = new WebSocket($url['host'], $url['port']);
        $client = $this->client->connect('/', '', [
            'AuthToken' => 'user5c5bXXXXXXX',
            'MarketId'  => 'de',
        ]);
```
results in this header:
```
User-Agent: php-client
Upgrade: websocket
Connection: Upgrade
AuthToken: user5c5bXXXXXXX
MarketId: de
Sec-WebSocket-Key: MarketId
Sec-WebSocket-Version: 13
```

but should be: 
```
User-Agent: php-client
Upgrade: websocket
Connection: Upgrade
AuthToken: user5c5bXXXXXXX
MarketId: de
Sec-WebSocket-Key: ZjJ3ejNlMThvNXXXX
Sec-WebSocket-Version: 13
```